### PR TITLE
[Issue 11] - no test motor data - cut and paste error. Missed one rename from drive to test

### DIFF
--- a/src/main/java/frc/robot/subsystems/TestMotor.java
+++ b/src/main/java/frc/robot/subsystems/TestMotor.java
@@ -25,7 +25,7 @@ public class TestMotor extends Subsystem {
   TalonSRX testMotor;
 
  public TestMotor() {
-    testMotor = new TalonSRX(RobotMap.driveMotorNumber);
+    testMotor = new TalonSRX(RobotMap.testMotorNumber);
     testMotor.setNeutralMode(NeutralMode.Brake);
  } 
 


### PR DESCRIPTION
We had an issue with the test motor where we weren't getting data. Mr. Nick hinted at the issue. This fix just updates that one line. 